### PR TITLE
Making things work with ESP Core 3.x for Arduino

### DIFF
--- a/DCCHardware.cpp
+++ b/DCCHardware.cpp
@@ -481,14 +481,23 @@ void setup_DCC_waveform_generator() {
 	
 	/******************************************/
 	#if defined(ESP32)			//ESP32 Modul
+	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+	/* ESP Arduino core 3.x
+	 */
+	/* Use auto allocated timer of 4 */
+	/* 1 tick takes 1us = 1MHz */
+	timer = timerBegin(1000000); // ESP core 3.x, old ESP core 2.x was: DCC_ESP_TIMER_ID, DCC_ESP_TIMER_PRESCALE, DCC_ESP_TIMER_FLAG);
+	#else
+	/* ESP Arduino core 2.x
+	 */
 	/* Use 1st timer of 4 */
 	/* 1 tick take 1/(80MHZ/80) = 1us so we set divider 80 and count up */
 	timer = timerBegin(DCC_ESP_TIMER_ID, DCC_ESP_TIMER_PRESCALE, DCC_ESP_TIMER_FLAG);
-	
+	#endif
+
 	/* Set alarm to call onTimer function every second 1 tick is 1us => 1 second is 1000000us */
 	/* Repeat the alarm (third parameter) */
-	timerAttachInterrupt(timer, &onTimerISR, true);
-	
+	// moved to section Enable the Interrupt (all MCUs): // timerAttachInterrupt(timer, &onTimerISR); // ESP core 3.x
 
 	DCC_TMR_OUTP_ONE_COUNT(); //start output "1"
 
@@ -540,7 +549,15 @@ void setup_DCC_waveform_generator() {
 	timer1_attachInterrupt(onTimerISR);
 	
 	#elif defined(ESP32)	//ESP32
+	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+	// Code for version 3.x
+	// nop
+	#else
+	/* ESP Arduino core 2.x
+	 */
 	timerAlarmEnable(timer);
+	#endif
+	timerAttachInterrupt(timer, &onTimerISR); // for ESP core 2.x and 3.x
 	
 	#else	//Arduino DUE
 	NVIC_EnableIRQ(DCC_ARM_MATCH_INT);	

--- a/DDCHardware_config.h
+++ b/DDCHardware_config.h
@@ -114,10 +114,29 @@ Dauer des Teil-Nullbits: t ≥ 100 µs, normal: 116µs
 #define DCC_ESP_TIMER_ID		 1		//the Timer number from 0 to 3
 #define DCC_ESP_TIMER_PRESCALE	 4		//prescale the value of the time divider
 #define DCC_ESP_TIMER_FLAG		 true	//flag true to count on the rising edge, false to count on the falling edge
-#define DCC_TMR_OUTP_ONE_HALF()  {timerAlarmWrite(timer, half_one_count, true); last_timer = half_one_count;}	
-#define DCC_TMR_OUTP_ONE_COUNT() {timerAlarmWrite(timer, one_count, true); last_timer = one_count;}	
-#define DCC_TMR_OUTP_ZERO_HIGH() {timerAlarmWrite(timer, zero_high_count, true); last_timer = zero_high_count;}    
-#define DCC_TMR_OUTP_ZERO_LOW()  {timerAlarmWrite(timer, zero_low_count, true); last_timer = zero_low_count;} 
+
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+/* ESP Arduino core 3.x
+ * from ESP 3.x docu:
+ * void timerAlarm(hw_timer_t * timer, uint64_t alarm_value, bool autoreload, uint64_t reload_count);
+ */
+#define DCC_TMR_OUTP_ONE_HALF()  {timerAlarm(timer, half_one_count, true, 0); last_timer = half_one_count;}
+#define DCC_TMR_OUTP_ONE_COUNT() {timerAlarm(timer, one_count, true, 0); last_timer = one_count;}
+#define DCC_TMR_OUTP_ZERO_HIGH() {timerAlarm(timer, zero_high_count, true, 0); last_timer = zero_high_count;}
+#define DCC_TMR_OUTP_ZERO_LOW()  {timerAlarm(timer, zero_low_count, true, 0); last_timer = zero_low_count;}
+#else
+/* ESP Arduino core 2.x
+ * from ESP 2.x docu:
+ * void timerAlarmWrite(hw_timer_t *timer, uint64_t alarm_value, bool autoreload);
+ * void timerAlarmEnable(hw_timer_t *timer);
+ */
+#define DCC_TMR_OUTP_ONE_HALF()  {timerAlarmWrite(timer, half_one_count, true); last_timer = half_one_count;}
+#define DCC_TMR_OUTP_ONE_COUNT() {timerAlarmWrite(timer, one_count, true); last_timer = one_count;}
+#define DCC_TMR_OUTP_ZERO_HIGH() {timerAlarmWrite(timer, zero_high_count, true); last_timer = zero_high_count;}
+#define DCC_TMR_OUTP_ZERO_LOW()  {timerAlarmWrite(timer, zero_low_count, true); last_timer = zero_low_count;}
+#endif
+
+
 
 /******************************************/
 //USE the Timer1 for the DCC Signal generation on AVR

--- a/README.txt
+++ b/README.txt
@@ -9,6 +9,12 @@ I build up the library to use it with the Arduino Z21pg central station: http://
 
 ===========
 
+Compared to upstream the following has been changed: 
+* compatibility for ESP32C3
+* conditional compilation for ESP Cores 2.x and 3.x for Arduino
+* some minor cleanup of if then else structures
+* indentation fixes
+
 modified by Philipp Gahtow 2015-2021 digitalmoba@arcor.de
 * - add a store for active loco, so you can request the actual state
 * - add a store for BasicAccessory states
@@ -31,3 +37,4 @@ modified by Philipp Gahtow 2015-2021 digitalmoba@arcor.de
 
 To install, see the general instructions for Arduino library installation here:
 http://arduino.cc/en/Guide/Environment#libraries
+


### PR DESCRIPTION
Making things work with ESP Core 3.x for Arduino 
checking at compile time for core 2.x vs. 3x
there is no detection for 1.x and it will try to use the 2.x implementation instead, but I guess that should be fine

closes #1 